### PR TITLE
fix: changed order of commands and removed unused ones

### DIFF
--- a/.github/workflows/d-lama-webapp-ci.yml
+++ b/.github/workflows/d-lama-webapp-ci.yml
@@ -27,21 +27,12 @@ jobs:
       - name: Install Dependencies
         run: npm install
         
+      - name: Run Tests
+        run: npm run test
+
       - name: Build
         run: npm run build
         
-      - name: Run Tests
-        run: npm run test
-        
-      - name: Install Ionic CLI
-        run: npm install -g @ionic/cli
-
-      - name: Build Ionic app
-        run: ionic build
-
-      - name: Run Ionic tests
-        run: ionic test
-      
       # Runs a single command using the runners shell
       - name: Run a one-line script
         run: echo Hello, world!


### PR DESCRIPTION
1. IMO the order of the commands is more suitable this way...you should first run the tests before doing the build because if the tests fail, then the build would be buggy.
2. `ionic build` is doing the same as `npm run build` -> removed
3. `ionic test` command is non-existent -> removed